### PR TITLE
Url plugin parse

### DIFF
--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -81,6 +81,12 @@ $snippets = include $sources['data'].'transport.snippets.php';
 if (empty($snippets)) $modx->log(modX::LOG_LEVEL_ERROR,'Could not package in snippets.');
 $category->addMany($snippets);
 
+/* add plugins */
+$modx->log(modX::LOG_LEVEL_INFO,'Packaging in plugins...');
+$plugins = include $sources['data'].'transport.plugins.php';
+if (empty($plugins)) $modx->log(modX::LOG_LEVEL_ERROR,'Could not package in plugins.');
+$category->addMany($plugins);
+
 /* add chunks */
 /*$modx->log(modX::LOG_LEVEL_INFO,'Packaging in chunks...');
 $chunks = include $sources['data'].'transport.chunks.php';

--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -85,24 +85,7 @@ $category->addMany($snippets);
 $modx->log(modX::LOG_LEVEL_INFO,'Packaging in plugins...');
 $plugins = include $sources['data'].'transport.plugins.php';
 if (empty($plugins)) $modx->log(modX::LOG_LEVEL_ERROR,'Could not package in plugins.');
-
-$attributes= array(
-    xPDOTransport::UNIQUE_KEY => 'name',
-    xPDOTransport::PRESERVE_KEYS => false,
-    xPDOTransport::UPDATE_OBJECT => true,
-    xPDOTransport::RELATED_OBJECTS => true,
-    xPDOTransport::RELATED_OBJECT_ATTRIBUTES => array (
-        'PluginEvents' => array(
-            xPDOTransport::PRESERVE_KEYS => true,
-            xPDOTransport::UPDATE_OBJECT => false,
-            xPDOTransport::UNIQUE_KEY => array('pluginid','event'),
-        ),
-    ),
-);
-foreach ($plugins as $plugin) {
-    $vehicle = $builder->createVehicle($plugin, $attributes);
-    $builder->putVehicle($vehicle);
-}
+$category->addMany($plugins);
 
 /* add chunks */
 /*$modx->log(modX::LOG_LEVEL_INFO,'Packaging in chunks...');
@@ -139,6 +122,19 @@ $attr = array(
             xPDOTransport::PRESERVE_KEYS => false,
             xPDOTransport::UPDATE_OBJECT => true,
             xPDOTransport::UNIQUE_KEY => 'name',
+        ),
+        'Plugins' => array(
+            xPDOTransport::UNIQUE_KEY => 'name',
+            xPDOTransport::PRESERVE_KEYS => false,
+            xPDOTransport::UPDATE_OBJECT => true,
+            xPDOTransport::RELATED_OBJECTS => true,
+            xPDOTransport::RELATED_OBJECT_ATTRIBUTES => array (
+                'PluginEvents' => array(
+                    xPDOTransport::PRESERVE_KEYS => true,
+                    xPDOTransport::UPDATE_OBJECT => false,
+                    xPDOTransport::UNIQUE_KEY => array('pluginid','event'),
+                ),
+            ),
         ),
         'Chunks' => array (
             xPDOTransport::PRESERVE_KEYS => false,

--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -85,7 +85,24 @@ $category->addMany($snippets);
 $modx->log(modX::LOG_LEVEL_INFO,'Packaging in plugins...');
 $plugins = include $sources['data'].'transport.plugins.php';
 if (empty($plugins)) $modx->log(modX::LOG_LEVEL_ERROR,'Could not package in plugins.');
-$category->addMany($plugins);
+
+$attributes= array(
+    xPDOTransport::UNIQUE_KEY => 'name',
+    xPDOTransport::PRESERVE_KEYS => false,
+    xPDOTransport::UPDATE_OBJECT => true,
+    xPDOTransport::RELATED_OBJECTS => true,
+    xPDOTransport::RELATED_OBJECT_ATTRIBUTES => array (
+        'PluginEvents' => array(
+            xPDOTransport::PRESERVE_KEYS => true,
+            xPDOTransport::UPDATE_OBJECT => false,
+            xPDOTransport::UNIQUE_KEY => array('pluginid','event'),
+        ),
+    ),
+);
+foreach ($plugins as $plugin) {
+    $vehicle = $builder->createVehicle($plugin, $attributes);
+    $builder->putVehicle($vehicle);
+}
 
 /* add chunks */
 /*$modx->log(modX::LOG_LEVEL_INFO,'Packaging in chunks...');

--- a/_build/data/transport.plugins.php
+++ b/_build/data/transport.plugins.php
@@ -33,28 +33,22 @@ $plugins[0]->set('id',1);
 $plugins[0]->set('name','DiscussUrlRouter');
 $plugins[0]->set('description','The plugin that routes the Discuss URLs.');
 $plugins[0]->set('plugincode', getSnippetContent($sources['source_core'].'/elements/plugins/urlrouter.discuss.php'));
+$plugins[0]->set('category', PKG_NAME);
 
 $events = array();
 
-$e = array(
-    'OnHandleRequest',
-);
-
-foreach ($e as $ev) {
-    $events[$ev] = $modx->newObject('modPluginEvent');
-    $events[$ev]->fromArray(array(
-        'event' => $ev,
-        'priority' => 0,
-        'propertyset' => 0
-    ),'',true,true);
-}
+$events['OnHandleRequest']= $modx->newObject('modPluginEvent');
+$events['OnHandleRequest']->fromArray(array(
+    'event' => 'OnHandleRequest',
+    'priority' => 0,
+    'propertyset' => 0,
+),'',true,true);
 
 if (is_array($events) && !empty($events)) {
     $plugins[0]->addMany($events);
-    $modx->log(xPDO::LOG_LEVEL_INFO,'Packaged in '.count($events).' Plugin Events for DiscussUrlRouter.'); flush();
+    $modx->log(xPDO::LOG_LEVEL_INFO,'Packaged in '.count($events).' Plugin Events.'); flush();
 } else {
-    $modx->log(xPDO::LOG_LEVEL_ERROR,'Could not find plugin events for DiscussUrlRouter!');
+    $modx->log(xPDO::LOG_LEVEL_ERROR,'Could not find plugin events!');
 }
-unset($events);
 
 return $plugins;

--- a/_build/data/transport.plugins.php
+++ b/_build/data/transport.plugins.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Discuss
+ *
+ * Copyright 2010-11 by Shaun McCormick <shaun@modx.com>
+ *
+ * This file is part of Discuss, a native forum for MODx Revolution.
+ *
+ * Discuss is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * Discuss is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * Discuss; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ *
+ * @package discuss
+ */
+/**
+ * @package discuss
+ * @subpackage build
+ */
+$plugins = array();
+
+/* create the plugin object */
+$plugins[0] = $modx->newObject('modPlugin');
+$plugins[0]->set('id',1);
+$plugins[0]->set('name','DiscussUrlRouter');
+$plugins[0]->set('description','The plugin that routes the Discuss URLs.');
+$plugins[0]->set('plugincode', getSnippetContent($sources['source_core'].'/elements/plugins/urlrouter.discuss.php'));
+
+$events = array();
+
+$e = array(
+    'OnPageNotFound',
+);
+
+foreach ($e as $ev) {
+    $events[$ev] = $modx->newObject('modPluginEvent');
+    $events[$ev]->fromArray(array(
+        'event' => $ev,
+        'priority' => 0,
+        'propertyset' => 0
+    ),'',true,true);
+}
+
+if (is_array($events) && !empty($events)) {
+    $plugins[0]->addMany($events);
+    $modx->log(xPDO::LOG_LEVEL_INFO,'Packaged in '.count($events).' Plugin Events for DiscussUrlRouter.'); flush();
+} else {
+    $modx->log(xPDO::LOG_LEVEL_ERROR,'Could not find plugin events for DiscussUrlRouter!');
+}
+unset($events);
+
+return $plugins;

--- a/_build/data/transport.plugins.php
+++ b/_build/data/transport.plugins.php
@@ -37,7 +37,7 @@ $plugins[0]->set('plugincode', getSnippetContent($sources['source_core'].'/eleme
 $events = array();
 
 $e = array(
-    'OnPageNotFound',
+    'OnHandleRequest',
 );
 
 foreach ($e as $ev) {

--- a/_build/data/transport.plugins.php
+++ b/_build/data/transport.plugins.php
@@ -33,7 +33,7 @@ $plugins[0]->set('id',1);
 $plugins[0]->set('name','DiscussUrlRouter');
 $plugins[0]->set('description','The plugin that routes the Discuss URLs.');
 $plugins[0]->set('plugincode', getSnippetContent($sources['source_core'].'/elements/plugins/urlrouter.discuss.php'));
-$plugins[0]->set('category', PKG_NAME);
+$plugins[0]->set('category', 0);
 
 $events = array();
 

--- a/core/components/discuss/elements/plugins/urlrouter.discuss.php
+++ b/core/components/discuss/elements/plugins/urlrouter.discuss.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Discuss
+ *
+ * Copyright 2010-11 by Shaun McCormick <shaun@modx.com>
+ *
+ * This file is part of Discuss, a native forum for MODx Revolution.
+ *
+ * Discuss is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * Discuss is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * Discuss; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ *
+ * @package discuss
+ */
+/**
+ * Handle Discuss URL Routing
+ *
+ * @var modX $modx
+ * @var Discuss $discuss
+ * @package discuss
+ */
+ 
+if ($modx->event->name != 'OnPageNotFound' || $modx->request->getResourceMethod() != 'alias' || $modx->context->key == 'mgr') {
+    return true;
+}
+$discuss = $modx->getService('discuss','Discuss',$modx->getOption('discuss.core_path',null,$modx->getOption('core_path').'components/discuss/').'model/discuss/');
+if (!($discuss instanceof Discuss)) return true;
+
+$discuss->url = $modx->makeUrl($modx->getOption('discuss.forums_resource_id'));
+
+$request = $modx->request->getResourceIdentifier('alias');
+
+// Checking to stop everything if we are sure that this is not our path or it doesn't have any parameters to parse (exact match of alias to the base resource alias)
+if (strpos($request, $discuss->url) !== 0 || strlen($request) === strlen($discuss->url) || array_key_exists($request, $modx->aliasMap)) {
+    return true;
+}
+
+$containersuffix = $modx->getOption('container_suffix', null, '/');
+
+$chunk = substr($request, 0, strrpos($request, $containersuffix));
+while (!empty($chunk)) {
+    if (array_key_exists($request, $modx->aliasMap)) {
+        return true;
+    }
+    $chunk = substr($chunk, 0, strrpos($chunk, $containersuffix));
+}
+
+// Now lets check that we have a valid manifest
+$f = $discuss->config['themePath'].'manifest.php';
+if (!file_exists($f)) {
+    return true;
+}
+$manifest = require $f;
+
+// Here I am sure that the URL is the one we need. Now lets break it into chunks (delimited by '/') and check against the manifest.
+$chunks = explode('/', $request);
+

--- a/core/components/discuss/elements/plugins/urlrouter.discuss.php
+++ b/core/components/discuss/elements/plugins/urlrouter.discuss.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * Discuss
  *
@@ -87,7 +87,7 @@ if (!function_exists('url_parser')) {
                                     $file = $discuss->request->getControllerFile($action);
                                     if (file_exists($file["file"]) && !is_dir($file["file"])) {
                                         $parameters['action'] = $action;
-                                        $request = trim(substr($request, $position), '/');
+                                        $request = trim(substr($request, strlen($action)), '/');
                                         $matched++;
                                     }
                                 }
@@ -97,7 +97,7 @@ if (!function_exists('url_parser')) {
                                         $file = $discuss->request->getControllerFile($actionname);
                                         if (file_exists($file["file"]) && !is_dir($file["file"])) {
                                             $parameters['action'] = $actionname;
-                                            $request = trim(substr($request, strpos($request, $actionname)), '/');
+                                            $request = trim(substr($request, strlen($actionname)), '/');
                                             $matched++;
                                             break;
                                         }
@@ -119,7 +119,7 @@ if (!function_exists('url_parser')) {
                             case 'constant':
                                 $position = strpos($request, $param['value']);
                                 if ($position===0) {
-                                    $request = trim(substr($request, $position), '/');
+                                    $request = trim(substr($request, strlen($param['value'])), '/');
                                     $matched++;
                                 }
                                 break;
@@ -132,8 +132,10 @@ if (!function_exists('url_parser')) {
                         }
                     }
                     if ($paramnumber === $matched) {
+                        if (!array_key_exists('action', $parameters)) {
+                            $parameters['action'] = $action;
+                        }
                         return $parameters;
-                        break;
                     }
                 }
             }
@@ -148,6 +150,9 @@ foreach ($manifest as $key => $value) {
     }
     if (array_key_exists('furl', $value) && count($value['furl'])>0) {
         $parsed = url_parser($key, $request, $value['furl'], $discuss);
+        if (is_array($parsed)) {
+            break;
+        }
     }
 }
 if (!is_array($parsed)) {

--- a/core/components/discuss/elements/plugins/urlrouter.discuss.php
+++ b/core/components/discuss/elements/plugins/urlrouter.discuss.php
@@ -1,4 +1,4 @@
-<?php
+<?
 /**
  * Discuss
  *
@@ -28,39 +28,34 @@
  * @var Discuss $discuss
  * @package discuss
  */
- 
-if ($modx->event->name != 'OnPageNotFound' || $modx->request->getResourceMethod() != 'alias' || $modx->context->key == 'mgr') {
-    return true;
+if ($modx->event->name != 'OnHandleRequest' || $modx->request->getResourceMethod() != 'alias' || $modx->context->key == 'mgr') {
+    return;
 }
 $discuss = $modx->getService('discuss','Discuss',$modx->getOption('discuss.core_path',null,$modx->getOption('core_path').'components/discuss/').'model/discuss/');
-if (!($discuss instanceof Discuss)) return true;
+if (!($discuss instanceof Discuss)) return;
 
 $discuss->loadRequest();
 $discuss->url = $modx->makeUrl($modx->getOption('discuss.forums_resource_id'));
 
-$request = $modx->request->getResourceIdentifier('alias');
-
+$request = trim($modx->request->getResourceIdentifier('alias'), '/');
 // Checking to stop everything if we are sure that this is not our path or it doesn't have any parameters to parse (exact match of alias to the base resource alias)
 if (strpos($request, $discuss->url) !== 0 || strlen($request) === strlen($discuss->url) || array_key_exists($request, $modx->aliasMap)) {
-    return true;
+    return;
 }
-
 $containersuffix = $modx->getOption('container_suffix', null, '/');
 
 $chunk = substr($request, 0, strrpos($request, $containersuffix));
 while (!empty($chunk)) {
     if (array_key_exists($request, $modx->aliasMap)) {
-        return true;
+        return;
     }
     $chunk = substr($chunk, 0, strrpos($chunk, $containersuffix));
 }
-
 // Now lets check that we have a valid manifest
-$f = $discuss->config['themePath'].'manifest.php';
-if (!file_exists($f)) {
-    return true;
+$manifest = $discuss->request->getManifest()
+if (!is_array($manifest)) {
+    return;
 }
-$manifest = require $f;
 
 // Now we sort the manifest array just to make sure that the actions of maximum length are checked first
 if (!function_exists('sorter')) {
@@ -159,7 +154,7 @@ if (!is_array($parsed)) {
     $parsed = url_parser('global', $request, $manifest['global']['furl']);
 }
 if (!is_array($parsed)) {
-    return true;
+    return;
 }
 
 foreach($parsed as $paramkey => $paramvalue) {
@@ -167,5 +162,4 @@ foreach($parsed as $paramkey => $paramvalue) {
     if(empty($modx->request->parameters['POST'][$paramkey]))
         $modx->request->parameters['REQUEST'][$paramkey]=$paramvalue;
 }
-
 $modx->sendForward($modx->getOption('discuss.forums_resource_id'));

--- a/core/components/discuss/elements/plugins/urlrouter.discuss.php
+++ b/core/components/discuss/elements/plugins/urlrouter.discuss.php
@@ -61,7 +61,7 @@ if (!is_array($manifest)) {
 if (!function_exists('sorter')) {
     function sorter($a, $b)
     {
-        return strlen($a) - strlen($b);    
+        return strlen($b) - strlen($a);
     }
 }
 uksort($manifest, "sorter");

--- a/core/components/discuss/elements/plugins/urlrouter.discuss.php
+++ b/core/components/discuss/elements/plugins/urlrouter.discuss.php
@@ -86,7 +86,9 @@ if (!function_exists('url_parser')) {
                                 if ($position===0) {
                                     $file = $discuss->request->getControllerFile($action);
                                     if (file_exists($file["file"]) && !is_dir($file["file"])) {
-                                        $parameters['action'] = $action;
+                                        if (!empty($action)) {
+                                            $parameters['action'] = $action;
+                                        }
                                         $request = trim(substr($request, strlen($action)), '/');
                                         $matched++;
                                     }
@@ -96,7 +98,9 @@ if (!function_exists('url_parser')) {
                                     while (!empty($actionname)) {
                                         $file = $discuss->request->getControllerFile($actionname);
                                         if (file_exists($file["file"]) && !is_dir($file["file"])) {
-                                            $parameters['action'] = $actionname;
+                                            if (!empty($actionname)) {
+                                                $parameters['action'] = $actionname;
+                                            }
                                             $request = trim(substr($request, strlen($actionname)), '/');
                                             $matched++;
                                             break;
@@ -112,7 +116,9 @@ if (!function_exists('url_parser')) {
                                     $position = strlen($request);
                                 }
                                 $data = substr($request, 0, $position);
-                                $parameters[$param['key']] = $data;
+                                if (!empty($data)) {
+                                    $parameters[$param['key']] = $data;
+                                }
                                 $request = trim(substr($request, $position), '/');
                                 $matched++;
                                 break;
@@ -154,6 +160,12 @@ foreach ($manifest as $key => $value) {
             break;
         }
     }
+    elseif (strpos($request, $key)===0) {
+        $parsed = url_parser($key, $request, $manifest['global']['furl'], $discuss);
+        if (is_array($parsed)) {
+            break;
+        }
+    }
 }
 if (!is_array($parsed)) {
     $parsed = url_parser('global', $request, $manifest['global']['furl'], $discuss);
@@ -164,10 +176,8 @@ if (!is_array($parsed)) {
 
 foreach($parsed as $paramkey => $paramvalue) {
     $modx->request->parameters['GET'][$paramkey]=$paramvalue;
-    $_GET[$paramkey]=$paramvalue;
     if(empty($modx->request->parameters['POST'][$paramkey])) {
         $modx->request->parameters['REQUEST'][$paramkey]=$paramvalue;
-        $_REQUEST[$paramkey]=$paramvalue;
     }
 }
 $modx->sendForward($modx->getOption('discuss.forums_resource_id'));

--- a/core/components/discuss/model/discuss/request/disrequest.class.php
+++ b/core/components/discuss/model/discuss/request/disrequest.class.php
@@ -332,10 +332,17 @@ class DisRequest {
      * @return mixed
      */
     public function getManifest() {
+        static $retrievedmanifest = false;
+        if ($retrievedmanifest!== false) {
+            return $retrievedmanifest;
+        }
         $f = $this->discuss->config['themePath'].'manifest.php';
         if (file_exists($f) || !is_dir($f)) {
-            return require $f;
+            $retrievedmanifest = require $f;
         }
-        return null;
+        else {
+            $retrievedmanifest = null;
+        }
+        return $retrievedmanifest;
     }
 }

--- a/core/components/discuss/model/discuss/request/disrequest.class.php
+++ b/core/components/discuss/model/discuss/request/disrequest.class.php
@@ -189,7 +189,7 @@ class DisRequest {
         $additional = $this->controller['controller'];
         
         $manifest = $this->getManifest();
-        if (is_array(manifest)) {
+        if (is_array($manifest)) {
             $registerJs = array('header' => array(), 'footer' => array());
 
             if (is_array($manifest) && array_key_exists('print', $manifest) && !empty($_REQUEST['print'])) {

--- a/core/components/discuss/model/discuss/request/disrequest.class.php
+++ b/core/components/discuss/model/discuss/request/disrequest.class.php
@@ -188,9 +188,8 @@ class DisRequest {
 	public function loadThemeOptions() {
         $additional = $this->controller['controller'];
         
-        $f = $this->discuss->config['themePath'].'manifest.php';
-        if (file_exists($f)) {
-            $manifest = require $f;
+        $manifest = $this->getManifest();
+        if (is_array(manifest)) {
             $registerJs = array('header' => array(), 'footer' => array());
 
             if (is_array($manifest) && array_key_exists('print', $manifest) && !empty($_REQUEST['print'])) {
@@ -327,4 +326,16 @@ class DisRequest {
         return $url;
     }
     
+    /**
+     * Gets the correct manifest for the theme. Returns null if fail to retrieve manifest
+     * 
+     * @return mixed
+     */
+    public function getManifest() {
+        $f = $this->discuss->config['themePath'].'manifest.php';
+        if (file_exists($f) || !is_dir($f)) {
+            return require $f;
+        }
+        return null;
+    }
 }

--- a/core/components/discuss/themes/default/manifest.php
+++ b/core/components/discuss/themes/default/manifest.php
@@ -44,6 +44,26 @@ $manifest = array(
             ),
             'inline' => 'DIS.url = "'.$this->discuss->url.'";DIS.shJsUrl = "'.$this->discuss->config['jsUrl'].'sh/";',
         ),
+        'furl' => array(
+            array(
+                'condition' => array(
+                    'type' => 'category',
+                ),
+                'data' => array(
+                    array('type' => 'constant', 'value' => 'category'),
+                    array('type' => 'variable-required', 'key' => 'category'),
+                    array('type' => 'variable', 'key' => 'category_name'),
+                    array('type' => 'allparameters'),
+                ),
+            ),
+            array(
+                'condition' => array(),
+                'data' => array(
+                    array('type' => 'action'),
+                    array('type' => 'allparameters'),
+                ),
+            ),
+        ),
     ),
     'print' => array(
         'css' => array(
@@ -83,6 +103,17 @@ $manifest = array(
             'showModerators' => true,
             'showPaginationIfOnePage' => false,
         ),
+        'furl' => array(
+            array(
+                'condition' => array(),
+                'data' => array(
+                    array('type' => 'constant', 'value' => 'board'),
+                    array('type' => 'variable-required', 'key' => 'board'),
+                    array('type' => 'variable', 'key' => 'board_name'),
+                    array('type' => 'allparameters'),
+                ),
+            ),
+        ),
     ),
     'board.xml' => array(
         'options' => array(
@@ -110,6 +141,17 @@ $manifest = array(
             'showMarkAsSpamOption' => true,
             'showTitleInBreadcrumbs' => true,
             'showPaginationIfOnePage' => true,
+        ),
+        'furl' => array(
+            array(
+                'condition' => array(),
+                'data' => array(
+                    array('type' => 'constant', 'value' => 'thread'),
+                    array('type' => 'variable-required', 'key' => 'thread'),
+                    array('type' => 'variable', 'key' => 'thread_name'),
+                    array('type' => 'allparameters'),
+                ),
+            ),
         ),
     ),
     'thread/new' => array(
@@ -208,6 +250,26 @@ $manifest = array(
     'user' => array(
         'options' => array(
             'showRecentPosts' => true,
+        ),
+        'furl' => array(
+            array(
+                'condition' => array(
+                    'type' => 'username',
+                ),
+                'data' => array(
+                    array('type' => 'constant', 'value' => 'u'),
+                    array('type' => 'variable-required', 'key' => 'user'),
+                    array('type' => 'allparameters'),
+                ),
+            ),
+            array(
+                'condition' => array(),
+                'data' => array(
+                    array('type' => 'constant', 'value' => 'user'),
+                    array('type' => 'parameter', 'key' => 'user'),
+                    array('type' => 'allparameters'),
+                ),
+            ),
         ),
     ),
     'user/subscriptions' => array(


### PR DESCRIPTION
Well, fnally made the plugin to parse the URLs instead of rewrites.

Was thinking about making also the possibility to parse from manifest the smf URLs, but it seems to be of too much overhead.

Probably separate plugin for SMF-links would be better...
