### PR TITLE
added cleanAlias function from modResource class for better FURLs

### DIFF
--- a/core/components/discuss/model/discuss/disboard.class.php
+++ b/core/components/discuss/model/discuss/disboard.class.php
@@ -891,11 +891,6 @@ class disBoard extends xPDOSimpleObject {
         /* decode named entities to the appropriate character for the character set */
         $alias = html_entity_decode($alias, ENT_QUOTES, $charset);
 
-        /* replace any remaining & with a lexicon value if available */
-        if ($this->xpdo instanceof modX && $this->xpdo->getService('lexicon','modLexicon')) {
-            $alias = str_replace('&', $this->xpdo->lexicon('and') ? ' ' . $this->xpdo->lexicon('and') . ' ' : ' and ', $alias);
-        }
-
         /* apply transliteration as configured */
         switch ($translit) {
             case '':
@@ -915,6 +910,11 @@ class disBoard extends xPDOSimpleObject {
                     }
                 }
                 break;
+        }
+        
+        /* replace any remaining & with a lexicon value if available */
+        if ($this->xpdo instanceof modX && $this->xpdo->getService('lexicon','modLexicon')) {
+            $alias = str_replace('&', $this->xpdo->lexicon('and') ? ' ' . $this->xpdo->lexicon('and') . ' ' : ' and ', $alias);
         }
 
         /* restrict characters as configured */

--- a/core/components/discuss/model/discuss/disboard.class.php
+++ b/core/components/discuss/model/discuss/disboard.class.php
@@ -791,7 +791,7 @@ class disBoard extends xPDOSimpleObject {
     public function getLastPostTitleSlug($key = 'last_post_title') {
         $title = $this->get($key);
         if (!empty($title)) {
-            $title = $this->cleanAlias($title);
+            $title = $this->xpdo->resource->cleanAlias($title);
         }
         return $title;
     }
@@ -849,131 +849,12 @@ class disBoard extends xPDOSimpleObject {
     public function getSlug() {
         $title = $this->get('name');
         if (!empty($title)) {
-            $title = $this->cleanAlias($title);
+            $title = $this->xpdo->resource->cleanAlias($title);
         } else {
             $title = $this->get('id');
         }
         return $title;
 
-    }
-    
-    /**
-     * Transforms a string to form a valid URL representation.
-     *
-     * @param string $alias A string to transform into a valid URL representation.
-     * @param array $options Options to append to or override configuration settings.
-     * @return string The transformed string.
-     */
-    public function cleanAlias($alias, array $options = array()) {
-        /* setup the various options */
-        $iconv = function_exists('iconv');
-        $mbext = function_exists('mb_strlen') && (boolean) $this->xpdo->getOption('use_multibyte', false);
-        $charset = strtoupper((string) $this->xpdo->getOption('modx_charset', $options, 'UTF-8'));
-        $delimiter = $this->xpdo->getOption('friendly_alias_word_delimiter', $options, '-');
-        $delimiters = $this->xpdo->getOption('friendly_alias_word_delimiters', $options, '-_');
-        $maxlength = (integer) $this->xpdo->getOption('friendly_alias_max_length', $options, 0);
-        $stripElementTags = (boolean) $this->xpdo->getOption('friendly_alias_strip_element_tags', $options, true);
-        $trimchars = $this->xpdo->getOption('friendly_alias_trim_chars', $options, '/.' . $delimiters);
-        $restrictchars = $this->xpdo->getOption('friendly_alias_restrict_chars', $options, 'pattern');
-        $restrictcharspattern = $this->xpdo->getOption('friendly_alias_restrict_chars_pattern', $options, '/[\0\x0B\t\n\r\f\a&=+%#<>"~`@\?\[\]\{\}\|\^\'\\\\]/');
-        $lowercase = (boolean) $this->xpdo->getOption('friendly_alias_lowercase_only', $options, true);
-        $translit = $this->xpdo->getOption('friendly_alias_translit', $options, $iconv ? 'iconv' : 'none');
-        $translitClass = $this->xpdo->getOption('friendly_alias_translit_class', $options, 'translit.modTransliterate');
-
-        /* strip html and optionally MODX element tags (stripped by default) */
-        if ($this->xpdo instanceof modX) {
-            $alias = $this->xpdo->stripTags($alias, '', $stripElementTags ? array() : null);
-        }
-
-        /* replace &nbsp; with the specified word delimiter */
-        $alias = str_replace('&nbsp;', $delimiter, $alias);
-
-        /* decode named entities to the appropriate character for the character set */
-        $alias = html_entity_decode($alias, ENT_QUOTES, $charset);
-
-        /* apply transliteration as configured */
-        switch ($translit) {
-            case '':
-            case 'none':
-                /* no transliteration */
-                break;
-            case 'iconv':
-                /* if iconv is available, use the built-in transliteration it provides */
-                $alias = iconv($mbext ? mb_detect_encoding($alias) : $charset, $charset . '//TRANSLIT//IGNORE', $alias);
-                break;
-            default:
-                /* otherwise look for a transliteration service class that will accept named transliteration tables */
-                if ($this->xpdo instanceof modX) {
-                    $translitClassPath = $this->xpdo->getOption('friendly_alias_translit_class_path', $options, $this->xpdo->getOption('core_path', $options, MODX_CORE_PATH) . 'components/');
-                    if ($this->xpdo->getService('translit', $translitClass, $translitClassPath, $options)) {
-                        $alias = $this->xpdo->translit->translate($alias, $translit);
-                    }
-                }
-                break;
-        }
-        
-        /* replace any remaining & with a lexicon value if available */
-        if ($this->xpdo instanceof modX && $this->xpdo->getService('lexicon','modLexicon')) {
-            $alias = str_replace('&', $this->xpdo->lexicon('and') ? ' ' . $this->xpdo->lexicon('and') . ' ' : ' and ', $alias);
-        }
-
-        /* restrict characters as configured */
-        switch ($restrictchars) {
-            case 'alphanumeric':
-                /* restrict alias to alphanumeric characters only */
-                $alias = preg_replace('/[^\.%A-Za-z0-9 _-]/', '', $alias);
-                break;
-            case 'alpha':
-                /* restrict alias to alpha characters only */
-                $alias = preg_replace('/[^\.%A-Za-z _-]/', '', $alias);
-                break;
-            case 'legal':
-                /* restrict alias to legal URL characters only */
-                $alias = preg_replace('/[\0\x0B\t\n\r\f\a&=+%#<>"~`@\?\[\]\{\}\|\^\'\\\\]/', '', $alias);
-                break;
-            case 'pattern':
-            default:
-                /* restrict alias using regular expression pattern configured (same as legal by default) */
-                if (!empty($restrictcharspattern)) {
-                    $alias = preg_replace($restrictcharspattern, '', $alias);
-                }
-        }
-
-        /* replace one or more space characters with word delimiter */
-        $alias = preg_replace('/\s+/u', $delimiter, $alias);
-
-        /* replace one or more instances of word delimiters with word delimiter */
-        $delimiterTokens = array();
-        for ($d = 0; $d < strlen($delimiters); $d++) {
-            $delimiterTokens[] = $delimiters{$d};
-        }
-        $delimiterPattern = '/[' . implode('|', $delimiterTokens) . ']+/';
-        $alias = preg_replace($delimiterPattern, $delimiter, $alias);
-
-        /* unless lowercase_only preference is explicitly off, change case to lowercase */
-        if ($lowercase) {
-            if ($mbext) {
-                /* if the mb extension is available use it to protect multi-byte chars */
-                $alias = mb_convert_case($alias, MB_CASE_LOWER, $charset);
-            } else {
-                /* otherwise, just use strtolower */
-                $alias = strtolower($alias);
-            }
-        }
-        /* trim specified chars from both ends of the alias */
-        $alias = trim($alias, $trimchars);
-
-        /* get the strlen of the alias (use mb extension if available) */
-        $length = $mbext ? mb_strlen($alias, $charset) : strlen($alias);
-
-        /* if maxlength is specified and exceeded, return substr with additional trim applied */
-        if ($maxlength > 0 && $length > $maxlength) {
-            $alias = substr($alias, 0, $maxlength);
-            $alias = trim($alias, $trimchars);
-            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "alias after maxlength applied = {$alias}");
-        }
-
-        return $alias;
     }
 
 }

--- a/core/components/discuss/model/discuss/disboard.class.php
+++ b/core/components/discuss/model/discuss/disboard.class.php
@@ -791,7 +791,7 @@ class disBoard extends xPDOSimpleObject {
     public function getLastPostTitleSlug($key = 'last_post_title') {
         $title = $this->get($key);
         if (!empty($title)) {
-            $title = trim(preg_replace('/[^A-Za-z0-9-]+/', '-', strtolower($title)),'-');
+            $title = $this->cleanAlias($title);
         }
         return $title;
     }

--- a/core/components/discuss/model/discuss/disboard.class.php
+++ b/core/components/discuss/model/discuss/disboard.class.php
@@ -849,11 +849,131 @@ class disBoard extends xPDOSimpleObject {
     public function getSlug() {
         $title = $this->get('name');
         if (!empty($title)) {
-            $title = trim(preg_replace('/[^A-Za-z0-9-]+/', '-', strtolower($title)),'-');
+            $title = $this->cleanAlias($title);
         } else {
             $title = $this->get('id');
         }
         return $title;
 
     }
+    
+    /**
+     * Transforms a string to form a valid URL representation.
+     *
+     * @param string $alias A string to transform into a valid URL representation.
+     * @param array $options Options to append to or override configuration settings.
+     * @return string The transformed string.
+     */
+    public function cleanAlias($alias, array $options = array()) {
+        /* setup the various options */
+        $iconv = function_exists('iconv');
+        $mbext = function_exists('mb_strlen') && (boolean) $this->xpdo->getOption('use_multibyte', false);
+        $charset = strtoupper((string) $this->xpdo->getOption('modx_charset', $options, 'UTF-8'));
+        $delimiter = $this->xpdo->getOption('friendly_alias_word_delimiter', $options, '-');
+        $delimiters = $this->xpdo->getOption('friendly_alias_word_delimiters', $options, '-_');
+        $maxlength = (integer) $this->xpdo->getOption('friendly_alias_max_length', $options, 0);
+        $stripElementTags = (boolean) $this->xpdo->getOption('friendly_alias_strip_element_tags', $options, true);
+        $trimchars = $this->xpdo->getOption('friendly_alias_trim_chars', $options, '/.' . $delimiters);
+        $restrictchars = $this->xpdo->getOption('friendly_alias_restrict_chars', $options, 'pattern');
+        $restrictcharspattern = $this->xpdo->getOption('friendly_alias_restrict_chars_pattern', $options, '/[\0\x0B\t\n\r\f\a&=+%#<>"~`@\?\[\]\{\}\|\^\'\\\\]/');
+        $lowercase = (boolean) $this->xpdo->getOption('friendly_alias_lowercase_only', $options, true);
+        $translit = $this->xpdo->getOption('friendly_alias_translit', $options, $iconv ? 'iconv' : 'none');
+        $translitClass = $this->xpdo->getOption('friendly_alias_translit_class', $options, 'translit.modTransliterate');
+
+        /* strip html and optionally MODX element tags (stripped by default) */
+        if ($this->xpdo instanceof modX) {
+            $alias = $this->xpdo->stripTags($alias, '', $stripElementTags ? array() : null);
+        }
+
+        /* replace &nbsp; with the specified word delimiter */
+        $alias = str_replace('&nbsp;', $delimiter, $alias);
+
+        /* decode named entities to the appropriate character for the character set */
+        $alias = html_entity_decode($alias, ENT_QUOTES, $charset);
+
+        /* replace any remaining & with a lexicon value if available */
+        if ($this->xpdo instanceof modX && $this->xpdo->getService('lexicon','modLexicon')) {
+            $alias = str_replace('&', $this->xpdo->lexicon('and') ? ' ' . $this->xpdo->lexicon('and') . ' ' : ' and ', $alias);
+        }
+
+        /* apply transliteration as configured */
+        switch ($translit) {
+            case '':
+            case 'none':
+                /* no transliteration */
+                break;
+            case 'iconv':
+                /* if iconv is available, use the built-in transliteration it provides */
+                $alias = iconv($mbext ? mb_detect_encoding($alias) : $charset, $charset . '//TRANSLIT//IGNORE', $alias);
+                break;
+            default:
+                /* otherwise look for a transliteration service class that will accept named transliteration tables */
+                if ($this->xpdo instanceof modX) {
+                    $translitClassPath = $this->xpdo->getOption('friendly_alias_translit_class_path', $options, $this->xpdo->getOption('core_path', $options, MODX_CORE_PATH) . 'components/');
+                    if ($this->xpdo->getService('translit', $translitClass, $translitClassPath, $options)) {
+                        $alias = $this->xpdo->translit->translate($alias, $translit);
+                    }
+                }
+                break;
+        }
+
+        /* restrict characters as configured */
+        switch ($restrictchars) {
+            case 'alphanumeric':
+                /* restrict alias to alphanumeric characters only */
+                $alias = preg_replace('/[^\.%A-Za-z0-9 _-]/', '', $alias);
+                break;
+            case 'alpha':
+                /* restrict alias to alpha characters only */
+                $alias = preg_replace('/[^\.%A-Za-z _-]/', '', $alias);
+                break;
+            case 'legal':
+                /* restrict alias to legal URL characters only */
+                $alias = preg_replace('/[\0\x0B\t\n\r\f\a&=+%#<>"~`@\?\[\]\{\}\|\^\'\\\\]/', '', $alias);
+                break;
+            case 'pattern':
+            default:
+                /* restrict alias using regular expression pattern configured (same as legal by default) */
+                if (!empty($restrictcharspattern)) {
+                    $alias = preg_replace($restrictcharspattern, '', $alias);
+                }
+        }
+
+        /* replace one or more space characters with word delimiter */
+        $alias = preg_replace('/\s+/u', $delimiter, $alias);
+
+        /* replace one or more instances of word delimiters with word delimiter */
+        $delimiterTokens = array();
+        for ($d = 0; $d < strlen($delimiters); $d++) {
+            $delimiterTokens[] = $delimiters{$d};
+        }
+        $delimiterPattern = '/[' . implode('|', $delimiterTokens) . ']+/';
+        $alias = preg_replace($delimiterPattern, $delimiter, $alias);
+
+        /* unless lowercase_only preference is explicitly off, change case to lowercase */
+        if ($lowercase) {
+            if ($mbext) {
+                /* if the mb extension is available use it to protect multi-byte chars */
+                $alias = mb_convert_case($alias, MB_CASE_LOWER, $charset);
+            } else {
+                /* otherwise, just use strtolower */
+                $alias = strtolower($alias);
+            }
+        }
+        /* trim specified chars from both ends of the alias */
+        $alias = trim($alias, $trimchars);
+
+        /* get the strlen of the alias (use mb extension if available) */
+        $length = $mbext ? mb_strlen($alias, $charset) : strlen($alias);
+
+        /* if maxlength is specified and exceeded, return substr with additional trim applied */
+        if ($maxlength > 0 && $length > $maxlength) {
+            $alias = substr($alias, 0, $maxlength);
+            $alias = trim($alias, $trimchars);
+            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "alias after maxlength applied = {$alias}");
+        }
+
+        return $alias;
+    }
+
 }

--- a/core/components/discuss/model/discuss/disthread.class.php
+++ b/core/components/discuss/model/discuss/disthread.class.php
@@ -1401,7 +1401,7 @@ class disThread extends xPDOSimpleObject {
         }
 
         if (!empty($title)) {
-            $title = $this->cleanAlias($title);
+            $title = $this->xpdo->resource->cleanAlias($title);
         } else {
             $title = $this->get('id');
         }
@@ -1409,125 +1409,6 @@ class disThread extends xPDOSimpleObject {
 
     }
     
-    /**
-     * Transforms a string to form a valid URL representation.
-     *
-     * @param string $alias A string to transform into a valid URL representation.
-     * @param array $options Options to append to or override configuration settings.
-     * @return string The transformed string.
-     */
-    public function cleanAlias($alias, array $options = array()) {
-        /* setup the various options */
-        $iconv = function_exists('iconv');
-        $mbext = function_exists('mb_strlen') && (boolean) $this->xpdo->getOption('use_multibyte', false);
-        $charset = strtoupper((string) $this->xpdo->getOption('modx_charset', $options, 'UTF-8'));
-        $delimiter = $this->xpdo->getOption('friendly_alias_word_delimiter', $options, '-');
-        $delimiters = $this->xpdo->getOption('friendly_alias_word_delimiters', $options, '-_');
-        $maxlength = (integer) $this->xpdo->getOption('friendly_alias_max_length', $options, 0);
-        $stripElementTags = (boolean) $this->xpdo->getOption('friendly_alias_strip_element_tags', $options, true);
-        $trimchars = $this->xpdo->getOption('friendly_alias_trim_chars', $options, '/.' . $delimiters);
-        $restrictchars = $this->xpdo->getOption('friendly_alias_restrict_chars', $options, 'pattern');
-        $restrictcharspattern = $this->xpdo->getOption('friendly_alias_restrict_chars_pattern', $options, '/[\0\x0B\t\n\r\f\a&=+%#<>"~`@\?\[\]\{\}\|\^\'\\\\]/');
-        $lowercase = (boolean) $this->xpdo->getOption('friendly_alias_lowercase_only', $options, true);
-        $translit = $this->xpdo->getOption('friendly_alias_translit', $options, $iconv ? 'iconv' : 'none');
-        $translitClass = $this->xpdo->getOption('friendly_alias_translit_class', $options, 'translit.modTransliterate');
-
-        /* strip html and optionally MODX element tags (stripped by default) */
-        if ($this->xpdo instanceof modX) {
-            $alias = $this->xpdo->stripTags($alias, '', $stripElementTags ? array() : null);
-        }
-
-        /* replace &nbsp; with the specified word delimiter */
-        $alias = str_replace('&nbsp;', $delimiter, $alias);
-
-        /* decode named entities to the appropriate character for the character set */
-        $alias = html_entity_decode($alias, ENT_QUOTES, $charset);
-
-        /* apply transliteration as configured */
-        switch ($translit) {
-            case '':
-            case 'none':
-                /* no transliteration */
-                break;
-            case 'iconv':
-                /* if iconv is available, use the built-in transliteration it provides */
-                $alias = iconv($mbext ? mb_detect_encoding($alias) : $charset, $charset . '//TRANSLIT//IGNORE', $alias);
-                break;
-            default:
-                /* otherwise look for a transliteration service class that will accept named transliteration tables */
-                if ($this->xpdo instanceof modX) {
-                    $translitClassPath = $this->xpdo->getOption('friendly_alias_translit_class_path', $options, $this->xpdo->getOption('core_path', $options, MODX_CORE_PATH) . 'components/');
-                    if ($this->xpdo->getService('translit', $translitClass, $translitClassPath, $options)) {
-                        $alias = $this->xpdo->translit->translate($alias, $translit);
-                    }
-                }
-                break;
-        }
-        
-        /* replace any remaining & with a lexicon value if available */
-        if ($this->xpdo instanceof modX && $this->xpdo->getService('lexicon','modLexicon')) {
-            $alias = str_replace('&', $this->xpdo->lexicon('and') ? ' ' . $this->xpdo->lexicon('and') . ' ' : ' and ', $alias);
-        }
-
-        /* restrict characters as configured */
-        switch ($restrictchars) {
-            case 'alphanumeric':
-                /* restrict alias to alphanumeric characters only */
-                $alias = preg_replace('/[^\.%A-Za-z0-9 _-]/', '', $alias);
-                break;
-            case 'alpha':
-                /* restrict alias to alpha characters only */
-                $alias = preg_replace('/[^\.%A-Za-z _-]/', '', $alias);
-                break;
-            case 'legal':
-                /* restrict alias to legal URL characters only */
-                $alias = preg_replace('/[\0\x0B\t\n\r\f\a&=+%#<>"~`@\?\[\]\{\}\|\^\'\\\\]/', '', $alias);
-                break;
-            case 'pattern':
-            default:
-                /* restrict alias using regular expression pattern configured (same as legal by default) */
-                if (!empty($restrictcharspattern)) {
-                    $alias = preg_replace($restrictcharspattern, '', $alias);
-                }
-        }
-
-        /* replace one or more space characters with word delimiter */
-        $alias = preg_replace('/\s+/u', $delimiter, $alias);
-
-        /* replace one or more instances of word delimiters with word delimiter */
-        $delimiterTokens = array();
-        for ($d = 0; $d < strlen($delimiters); $d++) {
-            $delimiterTokens[] = $delimiters{$d};
-        }
-        $delimiterPattern = '/[' . implode('|', $delimiterTokens) . ']+/';
-        $alias = preg_replace($delimiterPattern, $delimiter, $alias);
-
-        /* unless lowercase_only preference is explicitly off, change case to lowercase */
-        if ($lowercase) {
-            if ($mbext) {
-                /* if the mb extension is available use it to protect multi-byte chars */
-                $alias = mb_convert_case($alias, MB_CASE_LOWER, $charset);
-            } else {
-                /* otherwise, just use strtolower */
-                $alias = strtolower($alias);
-            }
-        }
-        /* trim specified chars from both ends of the alias */
-        $alias = trim($alias, $trimchars);
-
-        /* get the strlen of the alias (use mb extension if available) */
-        $length = $mbext ? mb_strlen($alias, $charset) : strlen($alias);
-
-        /* if maxlength is specified and exceeded, return substr with additional trim applied */
-        if ($maxlength > 0 && $length > $maxlength) {
-            $alias = substr($alias, 0, $maxlength);
-            $alias = trim($alias, $trimchars);
-            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "alias after maxlength applied = {$alias}");
-        }
-
-        return $alias;
-    }
-
 
     /** can* methods */
 

--- a/core/components/discuss/model/discuss/disthread.class.php
+++ b/core/components/discuss/model/discuss/disthread.class.php
@@ -1401,13 +1401,133 @@ class disThread extends xPDOSimpleObject {
         }
 
         if (!empty($title)) {
-            $title = trim(preg_replace('/[^A-Za-z0-9-]+/', '-', strtolower($title)),'-');
+            $title = $this->cleanAlias($title);
         } else {
             $title = $this->get('id');
         }
         return $title;
 
     }
+    
+    /**
+     * Transforms a string to form a valid URL representation.
+     *
+     * @param string $alias A string to transform into a valid URL representation.
+     * @param array $options Options to append to or override configuration settings.
+     * @return string The transformed string.
+     */
+    public function cleanAlias($alias, array $options = array()) {
+        /* setup the various options */
+        $iconv = function_exists('iconv');
+        $mbext = function_exists('mb_strlen') && (boolean) $this->xpdo->getOption('use_multibyte', false);
+        $charset = strtoupper((string) $this->xpdo->getOption('modx_charset', $options, 'UTF-8'));
+        $delimiter = $this->xpdo->getOption('friendly_alias_word_delimiter', $options, '-');
+        $delimiters = $this->xpdo->getOption('friendly_alias_word_delimiters', $options, '-_');
+        $maxlength = (integer) $this->xpdo->getOption('friendly_alias_max_length', $options, 0);
+        $stripElementTags = (boolean) $this->xpdo->getOption('friendly_alias_strip_element_tags', $options, true);
+        $trimchars = $this->xpdo->getOption('friendly_alias_trim_chars', $options, '/.' . $delimiters);
+        $restrictchars = $this->xpdo->getOption('friendly_alias_restrict_chars', $options, 'pattern');
+        $restrictcharspattern = $this->xpdo->getOption('friendly_alias_restrict_chars_pattern', $options, '/[\0\x0B\t\n\r\f\a&=+%#<>"~`@\?\[\]\{\}\|\^\'\\\\]/');
+        $lowercase = (boolean) $this->xpdo->getOption('friendly_alias_lowercase_only', $options, true);
+        $translit = $this->xpdo->getOption('friendly_alias_translit', $options, $iconv ? 'iconv' : 'none');
+        $translitClass = $this->xpdo->getOption('friendly_alias_translit_class', $options, 'translit.modTransliterate');
+
+        /* strip html and optionally MODX element tags (stripped by default) */
+        if ($this->xpdo instanceof modX) {
+            $alias = $this->xpdo->stripTags($alias, '', $stripElementTags ? array() : null);
+        }
+
+        /* replace &nbsp; with the specified word delimiter */
+        $alias = str_replace('&nbsp;', $delimiter, $alias);
+
+        /* decode named entities to the appropriate character for the character set */
+        $alias = html_entity_decode($alias, ENT_QUOTES, $charset);
+
+        /* replace any remaining & with a lexicon value if available */
+        if ($this->xpdo instanceof modX && $this->xpdo->getService('lexicon','modLexicon')) {
+            $alias = str_replace('&', $this->xpdo->lexicon('and') ? ' ' . $this->xpdo->lexicon('and') . ' ' : ' and ', $alias);
+        }
+
+        /* apply transliteration as configured */
+        switch ($translit) {
+            case '':
+            case 'none':
+                /* no transliteration */
+                break;
+            case 'iconv':
+                /* if iconv is available, use the built-in transliteration it provides */
+                $alias = iconv($mbext ? mb_detect_encoding($alias) : $charset, $charset . '//TRANSLIT//IGNORE', $alias);
+                break;
+            default:
+                /* otherwise look for a transliteration service class that will accept named transliteration tables */
+                if ($this->xpdo instanceof modX) {
+                    $translitClassPath = $this->xpdo->getOption('friendly_alias_translit_class_path', $options, $this->xpdo->getOption('core_path', $options, MODX_CORE_PATH) . 'components/');
+                    if ($this->xpdo->getService('translit', $translitClass, $translitClassPath, $options)) {
+                        $alias = $this->xpdo->translit->translate($alias, $translit);
+                    }
+                }
+                break;
+        }
+
+        /* restrict characters as configured */
+        switch ($restrictchars) {
+            case 'alphanumeric':
+                /* restrict alias to alphanumeric characters only */
+                $alias = preg_replace('/[^\.%A-Za-z0-9 _-]/', '', $alias);
+                break;
+            case 'alpha':
+                /* restrict alias to alpha characters only */
+                $alias = preg_replace('/[^\.%A-Za-z _-]/', '', $alias);
+                break;
+            case 'legal':
+                /* restrict alias to legal URL characters only */
+                $alias = preg_replace('/[\0\x0B\t\n\r\f\a&=+%#<>"~`@\?\[\]\{\}\|\^\'\\\\]/', '', $alias);
+                break;
+            case 'pattern':
+            default:
+                /* restrict alias using regular expression pattern configured (same as legal by default) */
+                if (!empty($restrictcharspattern)) {
+                    $alias = preg_replace($restrictcharspattern, '', $alias);
+                }
+        }
+
+        /* replace one or more space characters with word delimiter */
+        $alias = preg_replace('/\s+/u', $delimiter, $alias);
+
+        /* replace one or more instances of word delimiters with word delimiter */
+        $delimiterTokens = array();
+        for ($d = 0; $d < strlen($delimiters); $d++) {
+            $delimiterTokens[] = $delimiters{$d};
+        }
+        $delimiterPattern = '/[' . implode('|', $delimiterTokens) . ']+/';
+        $alias = preg_replace($delimiterPattern, $delimiter, $alias);
+
+        /* unless lowercase_only preference is explicitly off, change case to lowercase */
+        if ($lowercase) {
+            if ($mbext) {
+                /* if the mb extension is available use it to protect multi-byte chars */
+                $alias = mb_convert_case($alias, MB_CASE_LOWER, $charset);
+            } else {
+                /* otherwise, just use strtolower */
+                $alias = strtolower($alias);
+            }
+        }
+        /* trim specified chars from both ends of the alias */
+        $alias = trim($alias, $trimchars);
+
+        /* get the strlen of the alias (use mb extension if available) */
+        $length = $mbext ? mb_strlen($alias, $charset) : strlen($alias);
+
+        /* if maxlength is specified and exceeded, return substr with additional trim applied */
+        if ($maxlength > 0 && $length > $maxlength) {
+            $alias = substr($alias, 0, $maxlength);
+            $alias = trim($alias, $trimchars);
+            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "alias after maxlength applied = {$alias}");
+        }
+
+        return $alias;
+    }
+
 
     /** can* methods */
 

--- a/core/components/discuss/model/discuss/disthread.class.php
+++ b/core/components/discuss/model/discuss/disthread.class.php
@@ -1443,11 +1443,6 @@ class disThread extends xPDOSimpleObject {
         /* decode named entities to the appropriate character for the character set */
         $alias = html_entity_decode($alias, ENT_QUOTES, $charset);
 
-        /* replace any remaining & with a lexicon value if available */
-        if ($this->xpdo instanceof modX && $this->xpdo->getService('lexicon','modLexicon')) {
-            $alias = str_replace('&', $this->xpdo->lexicon('and') ? ' ' . $this->xpdo->lexicon('and') . ' ' : ' and ', $alias);
-        }
-
         /* apply transliteration as configured */
         switch ($translit) {
             case '':
@@ -1467,6 +1462,11 @@ class disThread extends xPDOSimpleObject {
                     }
                 }
                 break;
+        }
+        
+        /* replace any remaining & with a lexicon value if available */
+        if ($this->xpdo instanceof modX && $this->xpdo->getService('lexicon','modLexicon')) {
+            $alias = str_replace('&', $this->xpdo->lexicon('and') ? ' ' . $this->xpdo->lexicon('and') . ' ' : ' and ', $alias);
         }
 
         /* restrict characters as configured */


### PR DESCRIPTION
In non-english languages it is really important to use translit for the alias. When I worked on integrating translit, I thought it might be usefull to have the same clean process as on a resource alias.

So I copied the cleanAlias function from the modResource class and use it for the FURL generation.
That makes a lot better URLs!
