### PR TITLE
allow full rendering of subboard-details

### DIFF
--- a/core/components/discuss/hooks/board/getlist.php
+++ b/core/components/discuss/hooks/board/getlist.php
@@ -134,11 +134,27 @@ foreach ($boards as $board) {
         $ph = array();
         $sbl = array();
         foreach ($subBoards as $subboard) {
-            $sb = explode(':',$subboard);
-            $ph['id'] = $sb[0];
-            $ph['title'] = $sb[1];
+            $sb = explode(':',$subboard);            
+            $c = array(
+                'id' => $sb[0];
+            );
+            $sb = NULL;
+            $sbo = NULL;
 
-            $sbl[] = $discuss->getChunk($subBoardTpl,$ph);
+            $ck = 'discuss/board/index/'.md5(serialize($c));
+            $sb = $modx->cacheManager->get($ck);
+            if($sb === NULL) {
+                /* @var disBoard $board */
+                $sbo = $modx->getObject('disBoard', $c);
+                if($sbo !== NULL) {
+                    $sbo->calcLastPostPage();
+                    $sbo->getLastPostUrl();
+                    $sb = $sbo->toArray('', true, true);
+                    $modx->cacheManager->set($ck,$sb,$modx->getOption('discuss.cache_time',null,0));
+                }
+            }
+
+            $sbl[] = $discuss->getChunk($subBoardTpl,$sb);
         }
         $board['subforums'] = implode($subBoardSeparator,$sbl);
     }

--- a/core/components/discuss/themes/default/chunks/board/dissubforumlink.chunk.tpl
+++ b/core/components/discuss/themes/default/chunks/board/dissubforumlink.chunk.tpl
@@ -1,1 +1,1 @@
-<a href="[[DiscussUrlMaker? &action=`board` &params=`{"board":"[[+id]]"}`]]">[[+title]]</a>
+<a href="[[+url]]">[[+name]]</a>


### PR DESCRIPTION
This is one thing that annoyed me from the first release... subboards on the boards-overview aren't rendered with their full details, only a to-be-generated url and their name, preventing a more detailled usage.

This pull request allows the full and complete rendering of subboards (including the full url without using a workaround with a snippet) using the same placeholders like in the other chunks. The subboards are cached like the parent boards in the same script for performance-reasons.
